### PR TITLE
Fix explode() null deprecation in Plugin.php

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -52,7 +52,7 @@ class Plugin extends PluginBase
         Event::listen('cms.assets.render', function ($type, &$result) {
             $vite = Vite::instance();
 
-            $lines = array_map('trim', array_filter(explode("\n", $result)));
+            $lines = array_map('trim', array_filter(explode("\n", $result ?? '')));
 
             foreach ($lines as $number => $line) {
                 if (!str_contains($line, self::VITE_ASSET_TOKEN)) {


### PR DESCRIPTION
`explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/***/plugins/offline/vite/Plugin.php on line 55`